### PR TITLE
User-friendly Cammarano and Goes models

### DIFF
--- a/examples/01_anelasticity_models.py
+++ b/examples/01_anelasticity_models.py
@@ -1,7 +1,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import gdrift
-from gdrift.profile import RadialProfileSpline
 
 # In this tutorial we show how with the given functionalities
 # we can apply anelastic correction to an existing thermodynamic table
@@ -12,89 +11,6 @@ from gdrift.profile import RadialProfileSpline
 # - Andrault et al. (2011, EPSL)
 # - Hirschmann (2000, G3)
 
-
-def build_solidus():
-    # Load the solidus curve for the mantle from Andrault et al. (2011)
-    andrault_solidus = gdrift.SolidusProfileFromFile(
-        model_name="1d_solidus_Andrault_et_al_2011_EPSL",
-        description="Andrault et al. 2011, EPSL")
-
-    # Load the solidus curve for the mantle from Hirschmann (2000)
-    hirsch_solidus = gdrift.HirschmannSolidus()
-
-    # Combining the two
-    my_depths = []
-    my_solidus = []
-    for solidus_model in [hirsch_solidus, andrault_solidus]:
-        d_min, d_max = solidus_model.min_max_depth()
-        dpths = np.arange(d_min, d_max, 10e3)
-        my_depths.extend(dpths)
-        my_solidus.extend(solidus_model.at_depth(dpths))
-
-    # Avoding unnecessary extrapolation by setting the solidus temperature at maximum depth
-    my_depths.extend([3000e3])
-    my_solidus.extend([solidus_model.at_depth(dpths[-1])])
-
-    # building the solidus profile that was originally used by Ghelichkhan et al. (2021)
-    ghelichkhan_et_al = RadialProfileSpline(
-        depth=np.asarray(my_depths),
-        value=np.asarray(my_solidus),
-        name="Ghelichkhan et al 2021")
-
-    return ghelichkhan_et_al
-
-
-# Now the anelasticiy model by Cammarano et al can be constructed.
-# Here we use B g a for making Q_\mu, and we provide a rough Q_\kappa
-# From Goes et al, set to a constant value of 1000 in the upper and 10000 in the lower mantle.
-
-def build_anelasticity_model(solidus, q_profile: str = "Q1"):
-
-    cammarano_parameters = {
-        "Q1": {
-            "B": [0.5, 10],
-            "g": [20, 10]
-        },
-        "Q2": {
-            "B": [0.8, 15],
-            "g": [20, 10]
-        },
-        "Q3": {
-            "B": [1.1, 20],
-            "g": [20, 10]
-        },
-        "Q4": {
-            "B": [0.035, 2.25],
-            "g": [30, 15]
-        },
-        "Q5": {
-            "B": [0.056, 3.6],
-            "g": [30, 15]
-        },
-        "Q6": {
-            "B": [0.077, 4.95],
-            "g": [30, 15]
-        }
-    }
-
-    def B(x):
-        return np.where(x < 660e3, cammarano_parameters[q_profile]["B"][0], cammarano_parameters[q_profile]["B"][1])
-
-    def g(x):
-        return np.where(x < 660e3, cammarano_parameters[q_profile]["g"][0], cammarano_parameters[q_profile]["g"][1])
-
-    def a(x):
-        return 0.2
-
-    def omega(x):
-        return 1.
-
-    def Q_kappa(x):
-        return np.where(x < 660e3, 1e3, 1e4)
-
-    return gdrift.CammaranoAnelasticityModel(B=B, g=g, a=a, solidus=solidus, Q_bulk=Q_kappa, omega=omega)
-
-
 # Load PREM
 prem = gdrift.PreliminaryRefEarthModel()
 
@@ -104,16 +20,14 @@ slb_pyrolite = gdrift.ThermodynamicModel(
 pyrolite_elastic_s_speed = slb_pyrolite.compute_swave_speed()
 pyrolite_elastic_p_speed = slb_pyrolite.compute_pwave_speed()
 
-# building solidus model
-solidus_ghelichkhan = build_solidus()
-cammarano_q_model = "Q1"  # choose model from cammarano et al., 2003
-anelasticity = build_anelasticity_model(solidus_ghelichkhan, q_profile=cammarano_q_model)
-anelastic_slb_pyrolite = gdrift.apply_anelastic_correction(
-    slb_pyrolite, anelasticity)
-pyrolite_anelastic_s_speed = anelastic_slb_pyrolite.compute_swave_speed()
-pyrolite_anelastic_p_speed = anelastic_slb_pyrolite.compute_pwave_speed()
+# Apply anelastic correction
+cammarano_q_model = "Q6"  # Choose model from Cammarano et al. (2003)
+anelasticity = gdrift.CammaranoAnelasticityModel.from_q_profile(cammarano_q_model) # Instantiate the anelasticity model
+anelastic_slb_pyrolite = gdrift.apply_anelastic_correction(slb_pyrolite, anelasticity) # Apply anelastic correction to the thermodynamic model
+pyrolite_anelastic_s_speed = anelastic_slb_pyrolite.compute_swave_speed() # Calculate corrected shear wave speed
+pyrolite_anelastic_p_speed = anelastic_slb_pyrolite.compute_pwave_speed() # Calculate corrected pressure wave speed
 
-# contour lines to plot
+# Contour lines to plot
 cntr_lines = np.linspace(4000, 7000, 20)
 
 plt.close("all")
@@ -148,7 +62,7 @@ axes[1].text(0.5, 1.05, s="With Anelastic Correction",
              ha="center", va="center",
              transform=axes[1].transAxes, bbox=dict(facecolor=(1.0, 1.0, 0.7)))
 fig.colorbar(img[-1], ax=axes[0], cax=fig.add_axes([0.88,
-             0.1, 0.02, 0.8]), orientation="vertical", label="Shear-Wave Speed [m/s]")
+             0.1, 0.02, 0.8]), orientation="vertical", label="Shear Wave Speed [m/s]")
 
 
 # Figure 2:
@@ -162,15 +76,15 @@ ax_2.plot(pyrolite_anelastic_s_speed.get_y(),
 ax_2.plot(pyrolite_anelastic_s_speed.get_y(),
           pyrolite_elastic_s_speed.get_vals()[index, :], color="red", label="Elastic Model")
 ax_2.vlines(
-    [solidus_ghelichkhan.at_depth(pyrolite_anelastic_s_speed.get_x()[index])],
+    [anelasticity.solidus.at_depth(pyrolite_anelastic_s_speed.get_x()[index])],
     ymin=pyrolite_anelastic_s_speed.get_vals()[index, :].min(),
     ymax=pyrolite_anelastic_s_speed.get_vals()[index, :].max(),
     color="grey", label="Solidus", alpha=0.5)
 
-ax_2.set_xlabel("Temperature[K]")
-ax_2.set_ylabel("Shear Seismic-Wave Speed [m/s]")
+ax_2.set_xlabel("Temperature [K]")
+ax_2.set_ylabel("Shear Wave Speed [m/s]")
 ax_2.text(
-    0.5, 1.05, s=f"cammarano et al. {cammarano_q_model} at depth {pyrolite_anelastic_s_speed.get_x()[index] / 1e3:.1f} [km]",
+    0.5, 1.05, s=f"Cammarano et al. (2003) {cammarano_q_model} parameters at depth {pyrolite_anelastic_s_speed.get_x()[index] / 1e3:.1f} [km]",
     ha="center", va="center",
     transform=ax_2.transAxes, bbox=dict(facecolor=(1.0, 1.0, 0.7)))
 ax_2.legend()
@@ -179,7 +93,7 @@ plt.show()
 
 
 # Figure 3:
-# Looking at a specific depth of compressional seismic speed
+# Looking at a specific depth of pressure seismic speed
 plt.close(3)
 fig_3 = plt.figure(num=3)
 ax_3 = fig_3.add_subplot(111)
@@ -189,15 +103,15 @@ ax_3.plot(pyrolite_anelastic_p_speed.get_y(),
 ax_3.plot(pyrolite_anelastic_p_speed.get_y(),
           pyrolite_elastic_p_speed.get_vals()[index, :], color="red", label="Elastic Model")
 ax_3.vlines(
-    [solidus_ghelichkhan.at_depth(pyrolite_anelastic_p_speed.get_x()[index])],
+    [anelasticity.solidus.at_depth(pyrolite_anelastic_p_speed.get_x()[index])],
     ymin=pyrolite_anelastic_p_speed.get_vals()[index, :].min(),
     ymax=pyrolite_anelastic_p_speed.get_vals()[index, :].max(),
     color="grey", label="Solidus", alpha=0.5)
 
-ax_3.set_xlabel("Temperature[K]")
-ax_3.set_ylabel("Compressional Seismic-Wave Speed [m/s]")
+ax_3.set_xlabel("Temperature [K]")
+ax_3.set_ylabel("Pressure Wave Speed [m/s]")
 ax_3.text(
-    0.5, 1.05, s=f"cammarano et al. {cammarano_q_model} at depth {pyrolite_anelastic_p_speed.get_x()[index] / 1e3:.1f} [km]",
+    0.5, 1.05, s=f"Cammarano et al. (2003) {cammarano_q_model} parameters at depth {pyrolite_anelastic_p_speed.get_x()[index] / 1e3:.1f} [km]",
     ha="center", va="center",
     transform=ax_3.transAxes, bbox=dict(facecolor=(1.0, 1.0, 0.7)))
 ax_3.legend()

--- a/gdrift/__init__.py
+++ b/gdrift/__init__.py
@@ -2,7 +2,7 @@ from .constants import R_earth, R_cmb
 from .earthmodel3d import REVEALSeismicModel3D
 from .io import load_dataset, create_dataset_file
 from .mineralogy import ThermodynamicModel, compute_pwave_speed, compute_swave_speed
-from .anelasticity import CammaranoAnelasticityModel, apply_anelastic_correction
+from .anelasticity import CammaranoAnelasticityModel, GoesAnelasticityModel, apply_anelastic_correction
 from .profile import PreliminaryRefEarthModel, SolidusProfileFromFile, HirschmannSolidus
 from .utility import compute_gravity, compute_mass, compute_pressure, geodetic_to_cartesian, dimensionalise_coords, nondimensionalise_coords
 from .datasetnames import print_datasets_markdown

--- a/gdrift/anelasticity.py
+++ b/gdrift/anelasticity.py
@@ -2,59 +2,90 @@ from abc import ABC, abstractmethod
 import numpy
 
 # type hinting
-from .profile import RadialProfileSpline
-from typing import Type, Callable, Union
+from .profile import RadialProfileSpline, SolidusProfileFromFile, HirschmannSolidus
+from .mineralogy import ThermodynamicModel
+from typing import Type, TypeVar, Callable
 import numpy.typing as npt
 
+AnelasticityModel = TypeVar("AnelasticityModel", bound="BaseAnelasticityModel") # define a type hint for any subclass of `BaseAnelasticityModel`
 
 class BaseAnelasticityModel(ABC):
     """
-    Abstract base class for an anelasticity model.
     Abstract base class for an anelasticity model.
     All anelasticity models must be able to compute a Q matrix given depths and temperatures.
     """
 
     @abstractmethod
-    def compute_Q_shear(self, depths, temperatures):
+    def compute_Q_shear(self, depths: npt.ArrayLike, temperatures: npt.ArrayLike) -> npt.NDArray:
         """
         Computes the s-wave anelastic quality factor (Q) matrix for given depths and temperatures.
 
         Args:
-            depths (numpy.ndarray): Array of depths at which Q values are required.
-            temperatures (numpy.ndarray): Array of temperatures corresponding to the depths.
+            depths (npt.ArrayLike): Array of depths at which Q values are required.
+            temperatures (npt.ArrayLike): Array of temperatures corresponding to the depths.
 
         Returns:
-            numpy.ndarray: A matrix of Q values corresponding to the given depths and temperatures.
+            npt.NDArray: A matrix of Q values corresponding to the given depths and temperatures.
         """
         pass
 
     @abstractmethod
-    def compute_Q_bulk(self, depths, temperatures):
+    def compute_Q_bulk(self, depths: npt.ArrayLike, temperatures: npt.ArrayLike) -> npt.NDArray:
         """
         Computes the compressional anelastic quality factor (Q) matrix for given depths and temperatures.
 
         Args:
-            depths (numpy.ndarray): Array of depths at which Q values are required.
-            temperatures (numpy.ndarray): Array of temperatures corresponding to the depths.
+            depths (npt.ArrayLike): Array of depths at which Q values are required.
+            temperatures (npt.ArrayLike): Array of temperatures corresponding to the depths.
 
         Returns:
-            numpy.ndarray: A matrix of Q values corresponding to the given depths and temperatures.
+            npt.NDArray: A matrix of Q values corresponding to the given depths and temperatures.
         """
         pass
+
+    def build_ghelichkhan_solidus():
+        # Load the solidus curve for the mantle from Andrault et al. (2011)
+        andrault_solidus = SolidusProfileFromFile(
+            model_name="1d_solidus_Andrault_et_al_2011_EPSL",
+            description="Andrault et al. 2011, EPSL")
+
+        # Load the solidus curve for the mantle from Hirschmann (2000)
+        hirsch_solidus = HirschmannSolidus()
+
+        # Combining the two
+        my_depths = []
+        my_solidus = []
+        for solidus_model in [hirsch_solidus, andrault_solidus]:
+            d_min, d_max = solidus_model.min_max_depth()
+            dpths = numpy.arange(d_min, d_max, 10e3)
+            my_depths.extend(dpths)
+            my_solidus.extend(solidus_model.at_depth(dpths))
+
+        # Avoding unnecessary extrapolation by setting the solidus temperature at maximum depth
+        my_depths.extend([3000e3])
+        my_solidus.extend([solidus_model.at_depth(dpths[-1])])
+
+        # building the solidus profile that was originally used by Ghelichkhan et al. (2021)
+        ghelichkhan_et_al = RadialProfileSpline(
+            depth=numpy.asarray(my_depths),
+            value=numpy.asarray(my_solidus),
+            name="Ghelichkhan et al. 2021")
+
+        return ghelichkhan_et_al
 
 
 class CammaranoAnelasticityModel(BaseAnelasticityModel):
     """
-    A specific implementation of an anelasticity model following the approach by Cammarano et al., 2003.
+    A specific implementation of an anelasticity model following the approach by Cammarano et al. (2003).
     """
 
     def __init__(self,
                  B: Callable[[npt.ArrayLike], npt.NDArray],
                  g: Callable[[npt.ArrayLike], npt.NDArray],
                  a: Callable[[npt.ArrayLike], npt.NDArray],
+                 omega: Callable[[npt.ArrayLike], npt.NDArray],
                  solidus: Type[RadialProfileSpline],
-                 Q_bulk: Callable[[npt.ArrayLike], npt.NDArray],
-                 omega: Callable[[npt.ArrayLike], npt.NDArray]):
+                 Q_bulk: Callable[[npt.ArrayLike], npt.NDArray]):
         """
         Initialize the model with the given parameters.
 
@@ -62,8 +93,9 @@ class CammaranoAnelasticityModel(BaseAnelasticityModel):
             B Callable[[npt.ArrayLike], Union[npt.NDArray, float]]: Grain size-related attenuation scaling factor.
             g Callable[[npt.ArrayLike], Union[npt.NDArray, float]]: Activation energy factor equal to $H(P)/RT_\text{m}(P)$ (Karato, 1993).
             a Callable[[npt.ArrayLike], Union[npt.NDArray, float]]: Exponent controlling frequency dependence.
-            solidus (Type[RadialProfileSpline]): Solidus temperature for mantle.
             omega Callable[[npt.ArrayLike], Union[npt.NDArray, float]]: Seismic frequency.
+            solidus (Type[RadialProfileSpline]): Solidus temperature for mantle.
+            Q_bulk: Callable[[npt.ArrayLike], npt.NDArray]: Compressional anelastic quality factor.
         """
         self.B = B
         self.g = g
@@ -72,13 +104,13 @@ class CammaranoAnelasticityModel(BaseAnelasticityModel):
         self.solidus = solidus
         self.Q_bulk = Q_bulk
 
-    def __init__(self, q_profile: str, solidus: Type[RadialProfileSpline]):
+    @classmethod
+    def from_q_profile(cls, q_profile: str):
         """
-        Initialise the model with parameters corresponding to one of the Qn from Cammarano et al., 2003.
+        Initialise the model with parameters corresponding to one of the Qn from Cammarano et al. (2003). This uses the solidus from Ghelichkhan et al. (2021).
 
         Args:
             q_profile (str): The name of the parameter set to use (e.g. "Q1" for Q1).
-            solidus (Type[RadialProfileSpline]): Solidus temperature for mantle.
         """
         parameters = {
             "Q1": {
@@ -110,12 +142,14 @@ class CammaranoAnelasticityModel(BaseAnelasticityModel):
         if q_profile not in parameters.keys():
             raise ValueError(f"Invalid argument: {q_profile}. Must be one of {parameters.keys()}")
 
-        self.B = lambda x: numpy.where(x < 660e3, parameters[q_profile]["B"][0], parameters[q_profile]["B"][1])
-        self.g = lambda x: numpy.where(x < 660e3, parameters[q_profile]["g"][0], parameters[q_profile]["g"][1])
-        self.a = lambda x: 0.2 * numpy.ones_like(x)
-        self.omega = lambda x: numpy.ones_like(x)
-        self.solidus = solidus
-        self.Q_bulk = lambda x: numpy.where(x < 660e3, 1e3, 1e4)
+        B = lambda x: numpy.where(x < 660e3, parameters[q_profile]["B"][0], parameters[q_profile]["B"][1])
+        g = lambda x: numpy.where(x < 660e3, parameters[q_profile]["g"][0], parameters[q_profile]["g"][1])
+        a = lambda x: 0.2 * numpy.ones_like(x)
+        omega = lambda x: numpy.ones_like(x)
+        solidus = cls.build_ghelichkhan_solidus()
+        Q_bulk = lambda x: numpy.where(x < 660e3, 1e3, 1e4)
+        
+        return cls(B=B, g=g, a=a, omega=omega, solidus=solidus, Q_bulk=Q_bulk)
 
     def compute_Q_shear(self, depths: npt.ArrayLike, temperatures: npt.ArrayLike) -> npt.NDArray:
         """
@@ -150,25 +184,150 @@ class CammaranoAnelasticityModel(BaseAnelasticityModel):
 
         return Q_values
 
-    def compute_Q_bulk(self, depths, temperatures):
+    def compute_Q_bulk(self, depths: npt.ArrayLike, temperatures: npt.ArrayLike) -> npt.NDArray:
         """
+        Computes the compressional anelastic quality factor (Q) matrix for given depths and temperatures.
 
         Args:
-            depths (_type_): _description_
-            temperatures (_type_): _description_
+            depths (npt.ArrayLike): Array of depths at which Q values are required.
+            temperatures (npt.ArrayLike): Array of temperatures corresponding to the depths.
+
+        Returns:
+            npt.NDArray: A matrix of Q values corresponding to the given depths and temperatures.
+
+        Notes:
+            - If either `depths` or `temperatures` has a single element, it will be broadcasted.
         """
+        depths = numpy.asarray(depths)
+        temperatures = numpy.asarray(temperatures)
+
+        return self.Q_bulk(depths)
+    
+class GoesAnelasticityModel(BaseAnelasticityModel):
+    """
+    A specific implementation of an anelasticity model following the approach by Goes et al. (2004).
+    """
+
+    def __init__(self,
+                 Q0: Callable[[npt.ArrayLike], npt.NDArray],
+                 xi: Callable[[npt.ArrayLike], npt.NDArray],
+                 a: Callable[[npt.ArrayLike], npt.NDArray],
+                 omega: Callable[[npt.ArrayLike], npt.NDArray],
+                 solidus: Type[RadialProfileSpline],
+                 Q_bulk: Callable[[npt.ArrayLike], npt.NDArray]):
+        """
+        Initialize the model with the given parameters.
+
+        Args:
+            Q0 Callable[[npt.ArrayLike], Union[npt.NDArray, float]]: Grain size-related attenuation scaling factor (equivalent to $B$ in Cammarano et al. [2003]).
+            xi Callable[[npt.ArrayLike], Union[npt.NDArray, float]]: Activation energy factor equal to $aH(P)/RT_\text{m}(P)$ (Karato, 1993; equivalent to $ag$ in Cammarano et al. [2003]).
+            a Callable[[npt.ArrayLike], Union[npt.NDArray, float]]: Exponent controlling frequency dependence.
+            omega Callable[[npt.ArrayLike], Union[npt.NDArray, float]]: Seismic frequency.
+            solidus (Type[RadialProfileSpline]): Solidus temperature for mantle.
+            Q_bulk: Callable[[npt.ArrayLike], npt.NDArray]: Compressional anelastic quality factor.
+        """
+        self.Q0 = Q0
+        self.xi = xi
+        self.a = a
+        self.omega = omega
+        self.solidus = solidus
+        self.Q_bulk = Q_bulk
+
+    @classmethod
+    def from_q_profile(cls, q_profile: str):
+        """
+        Initialise the model with parameters corresponding to one of the Qn from Goes et al. (2003). This uses the solidus from Ghelichkhan et al. (2021).
+
+        Args:
+            q_profile (str): The name of the parameter set to use (e.g. "Q4" for Q4).
+        """
+        parameters = {
+            "Q4": {
+                "Q0": [3.5, 35],
+                "xi": [20, 10]
+            },
+            "Q6": {
+                "Q0": [0.5, 3.5],
+                "xi": [30, 20]
+            }
+        }
+
+        if q_profile not in parameters.keys():
+            raise ValueError(f"Invalid argument: {q_profile}. Must be one of {parameters.keys()}")
+
+        Q0 = lambda x: numpy.where(x < 660e3, parameters[q_profile]["Q0"][0], parameters[q_profile]["Q0"][1])
+        xi = lambda x: numpy.where(x < 660e3, parameters[q_profile]["xi"][0], parameters[q_profile]["xi"][1])
+        a = lambda x: 0.15 * numpy.ones_like(x)
+        omega = lambda x: numpy.ones_like(x)
+        solidus = cls.build_ghelichkhan_solidus()
+        Q_bulk = lambda x: numpy.where(x < 660e3, 1e3, 1e4)
+        
+        return cls(Q0=Q0, xi=xi, a=a, omega=omega, solidus=solidus, Q_bulk=Q_bulk)
+
+    def compute_Q_shear(self, depths: npt.ArrayLike, temperatures: npt.ArrayLike) -> npt.NDArray:
+        """
+        Compute the shear Q (attenuation quality factor) matrix based on input depths and temperatures.
+
+        Args:
+            depths (npt.ArrayLike): An array of depths at which Q values are to be calculated.
+            temperatures (npt.ArrayLike): An array of temperatures corresponding to the specified depths.
+
+        Returns:
+            npt.NDArray: A matrix of calculated Q values, representing the shear attenuation quality factor.
+
+        Notes:
+            - If either `depths` or `temperatures` has a single element, it will be broadcasted.
+            - For a full Q_shear matrix, `depths` and `temperatures` should be of compatible shapes (e.g., generated via `numpy.meshgrid`).
+            - The computation uses the properties of the material, such as `B`, `omega`, `a`, and `g`, along with the solidus temperature at a given depth.
+
+        Example:
+            # Example usage:
+            depths = numpy.linspace(0, 100, 50)  # 50 depth points from 0 to 100 km
+            # Corresponding temperatures
+            temperatures = numpy.linspace(800, 1200, 50)
+            Q_matrix = model.compute_Q_shear(depths, temperatures)
+        """
+        depths = numpy.asarray(depths)
+        temperatures = numpy.asarray(temperatures)
+
+        Q_values = (
+            self.Q0(depths) * (self.omega(depths)**self.a(depths)) * numpy.exp(
+                (self.a(depths) * self.xi(depths) * self.solidus.at_depth(depths)) / temperatures)
+        )
+
+        return Q_values
+
+    def compute_Q_bulk(self, depths: npt.ArrayLike, temperatures: npt.ArrayLike) -> npt.NDArray:
+        """
+        Computes the compressional anelastic quality factor (Q) matrix for given depths and temperatures.
+
+        Args:
+            depths (npt.ArrayLike): Array of depths at which Q values are required.
+            temperatures (npt.ArrayLike): Array of temperatures corresponding to the depths.
+
+        Returns:
+            npt.NDArray: A matrix of Q values corresponding to the given depths and temperatures.
+
+        Notes:
+            - If either `depths` or `temperatures` has a single element, it will be broadcasted.
+        """
+        depths = numpy.asarray(depths)
+        temperatures = numpy.asarray(temperatures)
+
         return self.Q_bulk(depths)
 
-def apply_anelastic_correction(thermo_model, anelastic_model):
+def apply_anelastic_correction(thermo_model: Type[ThermodynamicModel], anelastic_model: Type[AnelasticityModel]):
     """
     Apply anelastic corrections to seismic velocity data using the provided "anelastic_model"
-    within the low attenuation limit. The corrections are based on the equation:
-        $1 - \frac{V(anelastic)}{V(elastic)} = \frac{1}{2} \cot(\frac{\alpha \pi}{2}) Q^{-1}$
+    within the low attenuation limit. The corrections are based on the equation
+    $1 - \frac{V(anelastic)}{V(elastic)} = \frac{1}{2} \cot(\frac{\alpha \pi}{2}) Q^{-1},$
     as described by Stixrude & Lithgow-Bertelloni (doi:10.1029/2004JB002965, Eq-10).
 
-        thermo_model (ThermodynamicModel): The thermodynamic model containing temperature and depth data.
+        thermo_model (Type[ThermodynamicModel]): The thermodynamic model containing temperature and depth data.
+        anelastic_model (Type[AnelasticityModel]): The anelasticity model containing 
 
-        ThermodynamicModel: A new thermodynamic model with anelastically corrected seismic velocities.
+    Returns:
+        Type[ThermodynamicModel]: A new thermodynamic model with anelastically corrected seismic velocities.
 
     The returned model includes the following methods with anelastic corrections:
 


### PR DESCRIPTION
Add classmethod constructor to `CammaranoAnelasticityModel` for Cammarano et al. (2003) models Q1 to Q6 and create equivalent `GoesAnelasticityModel` for Goes et al. (2004) models Q4 & Q6.

@sghelichkhani, I'm not sure how you feel about having the function to create the solidus as a class method for `BaseAnelasticityModel`, but I couldn't come up with a more elegant solution. My motivation for this is that having some version of this in g-drift itself (rather than in the tutorial) is worthwhile as it means I don't have to copy the solidus-constructing function into every script where I want to apply an anelastic correction.