### PR TITLE
Allowing python3.11 and after

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "gdrift"
 version = "0.1.0"
 description = "Geodynamics Data Reformatting and Integration Facilitation Toolkit"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 license = {text = "MIT"}
 authors = [
     {name = "Sia Ghelichkhani", email = "siavash.ghelichkhan@anu.edu.au"},


### PR DESCRIPTION
Currently we require python3.12. That is not a strict requirement as long as python3.11 is supported by firedrake+numpy+scipy. This relaxes that requirement for us to be more flexible on gadi. 