### PR TITLE
Pin nbconvert<7.17 to fix docs build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ docs = [
     "mkdocs>=1.5",
     "mkdocs-material>=9.0",
     "mkdocstrings[python]>=0.24",
-    "mkdocs-jupyter>=0.24",
+    "mkdocs-jupyter>=0.24,<0.26",
 ]
 examples = [
     "matplotlib>=3.5",


### PR DESCRIPTION
mkdocs-jupyter 0.26.0 has a packaging bug where its template references mkdocs_html/assets/index.css but the file is not included in the distribution, causing the docs build to fail with `jinja2.exceptions.TemplateNotFound`. This pins mkdocs-jupyter to <0.26 until the upstream bug is fixed.

See #26 for tracking removal of this pin.