### PR TITLE
Move gdrift.constants import to notebook-only cell where it is used

### DIFF
--- a/examples/tomography_cross_section/demo.py
+++ b/examples/tomography_cross_section/demo.py
@@ -42,7 +42,6 @@
 
 import numpy as np
 import gdrift
-from gdrift.constants import R_earth, R_cmb
 
 # Loading REVEAL
 # --------------
@@ -140,6 +139,7 @@ print(f"dVs range: {np.nanmin(dvs_2d):.0f} to {np.nanmax(dvs_2d):.0f} m/s")
 # + tags=["active-ipynb"]
 # import matplotlib.pyplot as plt
 # from matplotlib.colors import TwoSlopeNorm
+# from gdrift.constants import R_earth, R_cmb
 #
 # half_span_deg = arc_deg / 2.0
 #


### PR DESCRIPTION
The R_earth and R_cmb imports are only needed in the matplotlib visualisation block, which is tagged active-ipynb. Moving the import there fixes the unused-import linting warning in the plain Python script.